### PR TITLE
Revamp sign-on section, other smaller changes

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
 
   <!--[if lt IE 9]><script src="assets/html5.js"></script><![endif]-->
 
-  <link href='https://fonts.googleapis.com/css?family=Habibi|Average' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Average' rel='stylesheet' type='text/css'>
 
   <link href="assets/site.css?{{ site.time | date: "%Y%m%j%H%M%S" }}" rel='stylesheet' type='text/css'>
 
@@ -69,8 +69,6 @@
     </nav>
 
     <article>
-      <p class="dateline">December 12, 2013</p>
-
       {{ content }}
     </article>
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -53,7 +53,7 @@
       </p>
 
       <p>
-        Authored and endorsed by a variety of <a href="#contributors-and-supporters">public interest groups</a>.
+        Authored and endorsed by a variety of <a href="#authors">public interest groups</a>.
       </p>
 
       <p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -53,7 +53,11 @@
       </p>
 
       <p>
-        <a href="http://prose.io/#unitedstates/licensing/edit/gh-pages/index.md">
+        Authored and endorsed by a variety of <a href="#contributors-and-supporters">public interest groups</a>.
+      </p>
+
+      <p>
+        <a href="https://github.com/unitedstates/licensing/issues">
           Suggestions welcome.
         </a>
       </p>

--- a/assets/site.css
+++ b/assets/site.css
@@ -3,11 +3,14 @@
 body {
   min-width: 1250px;
   color: #111;
-  font-family: "Average", "Habibi", "Georgia", serif;
-  font-size: 12pt;
+  font-family: "Times New Roman", "Georgia", serif;
+
+  font-size: 11pt;
   line-height: 23px;
   margin: 0; padding: 0;
 }
+
+h1, h2, h3, h4, h5, h6 {font-family: "Average", "Georgia", "Times New Roman", serif;}
 
 .main {width: 100%;}
 .main .inner {width: 700px; margin: 0 auto;}
@@ -33,7 +36,7 @@ nav ul {
   background-color: #e5e5e5;
 }
 
-nav ul li {font-size: 12pt; line-height: 22px;}
+nav ul li {line-height: 22px;}
 nav ul li a {
   display: block;
   padding: 7px 10px;
@@ -69,3 +72,18 @@ article h4 {font-size: 16pt; margin-top: 0; padding-top: 30px; margin-bottom: 10
 article a {color: #036;}
 
 article p.dateline {margin-bottom: 10px; text-align: right; color: #444;}
+article p.small {font-size: 10pt;}
+
+article ul.people, article ul.people li {
+  list-style-type: none;
+  list-style-position: outside;
+  padding-left: 0; padding-right: 0;
+  line-height: 28px;
+}
+
+article ul.people a {text-decoration: none; font-weight: bold;}
+article ul.people a:hover {text-decoration: underline; color: #111;}
+
+article ul.contributors {
+
+}

--- a/index.md
+++ b/index.md
@@ -90,11 +90,11 @@ The [Open Data Commons Public Domain Dedication and License (PDDL)][6] is very s
 
 #### Authors
 
-* Joshua Tauberer, [GovTrack.us](http://www.govtrack.us) (primary author)
-* Eric Mill, [Sunlight Foundation](http://sunlightfoundation.com)
-* Jonathan Gray, [Open Knowledge Foundation](http://okfn.org)
-* Parker Higgins, [Electronic Frontier Foundation](https://www.eff.org)
-* Michael Weinberg, [Public Knowledge](http://publicknowledge.org/)
+* Joshua Tauberer, GovTrack.us (primary author)
+* Eric Mill, Sunlight Foundation
+* Jonathan Gray, Open Knowledge Foundation
+* Parker Higgins, Electronic Frontier Foundation
+* Michael Weinberg, Public Knowledge
 {:.contributors.people}
 
 #### Supporters

--- a/index.md
+++ b/index.md
@@ -4,6 +4,9 @@ permalink: /
 filename: index.md
 ---
 
+December 12, 2013
+{:.dateline}
+
 ## Open Government Data
 
 ### Best-Practices Language for Making Data “License-Free”
@@ -86,27 +89,31 @@ The [Open Data Commons Public Domain Dedication and License (PDDL)][6] is very s
 [5]: http://ipmall.info/hosted_resources/copyrightcompendium.asp "Compendium II: Copyright Office Practices. 1998. Section 206.01."
 [6]: http://opendatacommons.org/licenses/pddl/
 
-#### Contributors and Supporters
+#### Contributors
 
-Joshua Tauberer, *[GovTrack.us](http://www.govtrack.us)*
+* Joshua Tauberer, [GovTrack.us](http://www.govtrack.us) (primary author)
+* Eric Mill, [Sunlight Foundation](http://sunlightfoundation.com)
+* Jonathan Gray, [Open Knowledge Foundation](http://okfn.org)
+* Parker Higgins, [Electronic Frontier Foundation](https://www.eff.org)
+* Michael Weinberg, [Public Knowledge](http://publicknowledge.org/)
+{:.contributors.people}
 
-Eric Mill, *[Sunlight Foundation](http://sunlightfoundation.com)*
+#### Supporters
 
-Jonathan Gray, *[Open Knowledge Foundation](http://okfn.org)*
-
-Parker Higgins, *[Electronic Frontier Foundation](https://www.eff.org)*
-
-Michael Weinberg, *[Public Knowledge](http://publicknowledge.org/)*
-
-*[Center for Democracy and Technology](https://www.cdt.org/)*
-
-*[Free Law Project](http://freelawproject.org/)*
-
-*[OpenGov Foundation](http://opengovfoundation.org/)*
-
-*[Public.Resource.Org](https://public.resource.org/)*
+* [GovTrack.us](http://www.govtrack.us)
+* [Sunlight Foundation](http://sunlightfoundation.com)
+* [Open Knowledge Foundation](http://okfn.org)
+* [Electronic Frontier Foundation](https://www.eff.org)
+* [Public Knowledge](http://publicknowledge.org/)
+* [Center for Democracy and Technology](https://www.cdt.org/)
+* [Free Law Project](http://freelawproject.org/)
+* [OpenGov Foundation](http://opengovfoundation.org/)
+* Carl Malamud, [Public.Resource.Org](https://public.resource.org/)
+* Jim Harper, [WashingtonWatch.com](http://www.washingtonwatch.com/)
+{:.supporters.people}
 
 We also thank Timothy Vollmer, Puneet Kishor, and other reviewers for their discussion and ideas, many of which we have borrowed here. Our gratitude does not imply their endorsement.
+{:.small}
 
 #### History
 

--- a/index.md
+++ b/index.md
@@ -88,26 +88,21 @@ The [Open Data Commons Public Domain Dedication and License (PDDL)][6] is very s
 
 #### Contributors and Supporters
 
-Joshua Tauberer<br/>
-*[GovTrack.us](http://www.govtrack.us)*
+Joshua Tauberer, *[GovTrack.us](http://www.govtrack.us)*
 
-Eric Mill<br/>
-*[Sunlight Foundation](http://sunlightfoundation.com)*
+Eric Mill, *[Sunlight Foundation](http://sunlightfoundation.com)*
 
-Jonathan Gray<br/>
-*[Open Knowledge Foundation](http://okfn.org)*
+Jonathan Gray, *[Open Knowledge Foundation](http://okfn.org)*
 
-Ellen Miller<br/>
-*[Sunlight Foundation](http://sunlightfoundation.com)*
+Parker Higgins, *[Electronic Frontier Foundation](https://www.eff.org)*
 
-Joseph Lorenzo Hall<br/>
+Michael Weinberg, *[Public Knowledge](http://publicknowledge.org/)*
+
 *[Center for Democracy and Technology](https://www.cdt.org/)*
 
-Parker Higgins<br/>
-*[Electronic Frontier Foundation](https://www.eff.org)*
+*[OpenGov Foundation](http://opengovfoundation.org/)*
 
-Michael Weinberg<br/>
-*[Public Knowledge](http://publicknowledge.org/)*
+*[Public.Resource.Org](http://public.resource.org/)*
 
 We also thank Timothy Vollmer, Puneet Kishor, and other reviewers for their discussion and ideas, many of which we have borrowed here. Our gratitude does not imply their endorsement.
 

--- a/index.md
+++ b/index.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 permalink: /
-filename: index.md
 ---
 
 December 12, 2013
@@ -117,6 +116,6 @@ We also thank Timothy Vollmer, Puneet Kishor, and other reviewers for their disc
 
 #### History
 
-August 19, 2013. First published.
+[August 19, 2013](/v1.html). First published.
 
-December 12, 2013. Rewrote the introduction. Removed "However"s in the suggested language. Added sections on determining IP status, that data is not copyrightable as such, and that this applies to software as well as data. Corrected typos. Added OKFN (removed the asterisk), EFF, Public Knowledge, Free Law Project, OpenGov Foundation, Public Resource.
+December 12, 2013. Rewrote the introduction. Removed "However"s in the suggested language. Added sections on determining IP status, that data is not copyrightable as such, and that this applies to software as well as data. Corrected typos. Updated signers list.

--- a/index.md
+++ b/index.md
@@ -116,6 +116,6 @@ We also thank Timothy Vollmer, Puneet Kishor, and other reviewers for their disc
 
 #### History
 
-[August 19, 2013](/v1.html). First published.
+[August 19, 2013](v1.html). First published.
 
 December 12, 2013. Rewrote the introduction. Removed "However"s in the suggested language. Added sections on determining IP status, that data is not copyrightable as such, and that this applies to software as well as data. Corrected typos. Updated signers list.

--- a/index.md
+++ b/index.md
@@ -88,7 +88,7 @@ The [Open Data Commons Public Domain Dedication and License (PDDL)][6] is very s
 [5]: http://ipmall.info/hosted_resources/copyrightcompendium.asp "Compendium II: Copyright Office Practices. 1998. Section 206.01."
 [6]: http://opendatacommons.org/licenses/pddl/
 
-#### Contributors
+#### Authors
 
 * Joshua Tauberer, [GovTrack.us](http://www.govtrack.us) (primary author)
 * Eric Mill, [Sunlight Foundation](http://sunlightfoundation.com)

--- a/index.md
+++ b/index.md
@@ -104,7 +104,7 @@ Michael Weinberg, *[Public Knowledge](http://publicknowledge.org/)*
 
 *[OpenGov Foundation](http://opengovfoundation.org/)*
 
-*[Public.Resource.Org](http://public.resource.org/)*
+*[Public.Resource.Org](https://public.resource.org/)*
 
 We also thank Timothy Vollmer, Puneet Kishor, and other reviewers for their discussion and ideas, many of which we have borrowed here. Our gratitude does not imply their endorsement.
 

--- a/index.md
+++ b/index.md
@@ -90,8 +90,8 @@ The [Open Data Commons Public Domain Dedication and License (PDDL)][6] is very s
 
 #### Authors
 
-* Joshua Tauberer, GovTrack.us (primary author)
-* Eric Mill, Sunlight Foundation
+* [Joshua Tauberer](http://razor.occams.info), GovTrack.us (primary author)
+* [Eric Mill](https://twitter.com/konklone), Sunlight Foundation
 * Jonathan Gray, Open Knowledge Foundation
 * Parker Higgins, Electronic Frontier Foundation
 * Michael Weinberg, Public Knowledge

--- a/index.md
+++ b/index.md
@@ -100,6 +100,8 @@ Michael Weinberg, *[Public Knowledge](http://publicknowledge.org/)*
 
 *[Center for Democracy and Technology](https://www.cdt.org/)*
 
+*[Free Law Project](http://freelawproject.org/)*
+
 *[OpenGov Foundation](http://opengovfoundation.org/)*
 
 *[Public.Resource.Org](http://public.resource.org/)*
@@ -110,4 +112,4 @@ We also thank Timothy Vollmer, Puneet Kishor, and other reviewers for their disc
 
 August 19, 2013. First published.
 
-December 12, 2013. Rewrote the introduction. Removed "However"s in the suggested language. Added sections on determining IP status, that data is not copyrightable as such, and that this applies to software as well as data. Corrected typos. Added OKFN (removed the asterisk), EFF, Public Knowledge, OpenGov Foundation, Public Resource.
+December 12, 2013. Rewrote the introduction. Removed "However"s in the suggested language. Added sections on determining IP status, that data is not copyrightable as such, and that this applies to software as well as data. Corrected typos. Added OKFN (removed the asterisk), EFF, Public Knowledge, Free Law Project, OpenGov Foundation, Public Resource.

--- a/index.md
+++ b/index.md
@@ -110,4 +110,4 @@ We also thank Timothy Vollmer, Puneet Kishor, and other reviewers for their disc
 
 August 19, 2013. First published.
 
-December 12, 2013. Rewrote the introduction. Removed "However"s in the suggested language. Added sections on determining IP status, that data is not copyrightable as such, and that this applies to software as well as data. Corrected typos. Added OKFN (removed the asterisk), EFF, and PK.
+December 12, 2013. Rewrote the introduction. Removed "However"s in the suggested language. Added sections on determining IP status, that data is not copyrightable as such, and that this applies to software as well as data. Corrected typos. Added OKFN (removed the asterisk), EFF, Public Knowledge, OpenGov Foundation, Public Resource.

--- a/v1.md
+++ b/v1.md
@@ -1,0 +1,102 @@
+---
+layout: default
+permalink: /v1.html
+---
+
+August 19, 2013
+{:.dateline}
+
+### Open Government Data: Best-Practices Language for Making Data "License-Free"
+
+Public government data is becoming an increasingly important part of the modern free press, industries from weather forecasting to business intelligence, and the repertoire of tools that can increase the efficiency of government services and support civic participation.
+
+Open government data has been defined in many ways. [One definition][1] uses eight core principles. As a definition, it does not attempt to say what should be open but rather articulates the consensus understanding of what it means to be open. One principle, in its simplest form, states that open government data is "license-free," or in other words that the data has no restrictions on use except as set forth in law.
+
+**This document provides language to affix to data publications so that they may meet, or to make it clear that they meet, the criteria of the "license-free" principle. The language is intended for U.S. federal government agencies.**
+
+#### What You Need to Know
+
+1. Data is "license-free" only if a) copyright, trademark, and similar laws do not apply or have been waived, and b) there are no restrictions on use or sharing of the data except as set forth in existing law.
+2. Copyright applies to some government data but not others (and never to U.S. law). When it applies, it must be waived by the agency (or owner if not the agency) for the data to meet the "license-free" principle. In this case, data is dedicated to the public domain, not licensed.
+3. An "open license" is different. "Open licenses" are designed for other definitions of open (such as open source, open content, and open knowledge), but these exploit copyright protections to enforce their terms. A fear of copyright infringement may hinder innovation and accountability.
+4. Data is more valuable when its copyright status is clear through an explicit statement.
+5. [Foreign copyright may apply to any government data.][2] A waiver of foreign copyright protections is suggested, especially if foreign use of the data is important.
+6. The [Creative Commons CC0 Public Domain Dedication][3] is a widely adopted legal tool allowing a creator to dedicate his/her work to the public domain. It is a statement that waives both domestic and foreign copyright protections and related rights over a work to whatever extent that they can be waived.
+
+We provide below recommended language for five common situations. The language should be placed in the data package’s README or LICENSE file, at a minimum, and in data catalog listings when possible.
+
+#### For U.S. Federal Government Works
+
+Copyright protection is not available for works of the United States Government under 17 USC § 105 unless a specific exemption applies. We recommend the following language when the data is believed to not be copyrightable:
+
+> As a work of the United States Government, this package is in the public domain within the United States. Additionally, [Agency Name] waives copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication (which can be found at http://creativecommons.org/publicdomain/zero/1.0/).
+
+*This language is in use by the Department of Health & Human Services for its [ckanext-datajson project on GitHub](https://github.com/HHS/ckanext-datajson).*
+
+When mixing government and non-government works, such as on an official government blog with public contributors, we recommend that the non-governmental contributors be required to waive copyright protection to their submissions in a similar manner as above. In some instances, such as contributions to a blog, licensing non-governmental contributions in a manner that meets the requirements of [the Open Definition][4] may be appropriate, but bear in mind that such contributions would not be "license-free" and thus might not be considered open.
+
+*WhiteHouse.gov uses this mixed approach at http://www.whitehouse.gov/copyright.*
+
+If a statutory exemption to 17 USC § 105 is applicable:
+
+> This is a work of the United States Government that is exempt from 17 USC § 105. However, [Agency Name] waives copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication (which can be found at http://creativecommons.org/publicdomain/zero/1.0/).
+
+#### For Government Works Produced by a Contractor
+
+Works produced under a contract with the government are typically subject to copyright protection. If the contract provides that ownership of the work is transferred to the government, use:
+
+> This work was created through a government contract which assigned copyright to [the United States Government or Agency name]. However, [Agency Name] waives copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication (which can be found at http://creativecommons.org/publicdomain/zero/1.0/).
+
+Or if copyright remains with the contractor, use:
+
+> This work was produced by [Contractor Name] in the performance of a contract with [Agency Name] (contract number [contract number]). [Contractor Name] waives copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication (which can be found at http://creativecommons.org/publicdomain/zero/1.0/).
+
+#### For Primary Legal Materials
+
+The courts have ruled that the law — i.e. edicts of government — is not protected by copyright (see Banks v. Manchester, 128 U.S. 244, 253 (1888) and other cases). This has also been [the position of the U.S. Copyright Office][5].
+
+For federal government primary legal materials, the language for federal government works listed above will typically suffice. For other aspects of law that do not fall into one of the categories above, such as standards incorporated by reference, we recommend the following:
+
+> This work contains laws, which are not subject to U.S. copyright protection. Additionally, [Body] waives copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication (which can be found at http://creativecommons.org/publicdomain/zero/1.0/).
+
+When publishing laws along side annotations in which copyright protections are asserted, we strongly recommend publishing an un-annotated copy of the law with the statement above.
+
+*The Council of the District of Columbia uses CC0 to waive copyright on the DC Code at http://dccouncil.us/UnofficialDCCode.*
+
+#### Additional Notes
+
+Click-through end user agreements and other terms of use statements that bind the user after he/she has acquired the data are always incompatible with the license-free principle. Terms of use may be used to protect the integrity of the government computer systems the data is being downloaded from but cannot restrict use of open government data or bind the end user once the data has been acquired.
+
+The Open Data Commons Public Domain Dedication and License (PDDL) is very similar to the Creative Commons CC0. It may be used in place of CC0.
+
+In any case in which CC0 has been applied, it would also be appropriate to use the [Creative Commons Public Domain Mark][6], which is an icon to indicate the worldwide public domain status of a work.
+
+"Open licensing" presumes copyright protection. Since for many types of government data copyright protections do not apply, traditional open licenses would be legally inappropriate. Note that the CC0 public domain dedication is not a license: It is a waiver. Be careful not to call use of CC0 "open licensing."
+
+[1]: http://opengovdata.org "Open Government Working Group 2007"
+[2]: http://www.copyright.gov/history/law/clrev_94-1476.pdf "House Report 94-1476, page 59."
+[3]: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+[4]: http://opendefinition.org/
+[5]: http://ipmall.info/hosted_resources/copyrightcompendium.asp "Compendium II: Copyright Office Practices. 1998. Section 206.01."
+[6]: http://creativecommons.org/publicdomain/mark/1.0/
+
+#### Contributors and Supporters
+
+Joshua Tauberer<br/>
+*[GovTrack.us](http://www.govtrack.us)*
+
+Eric Mill<br/>
+*[Sunlight Foundation](http://sunlightfoundation.com)*
+
+Jonathan Gray<br/>
+*[Open Knowledge Foundation](http://okfn.org)* *
+
+Ellen Miller<br/>
+*[Sunlight Foundation](http://sunlightfoundation.com)*
+
+Joseph Lorenzo Hall<br/>
+*[Center for Democracy and Technology](https://www.cdt.org/)*
+
+\* Affiliation is for identification purposes only.
+
+We also thank Timothy Vollmer, Puneet Kishor, and other reviewers for their discussion and ideas, many of which we have borrowed here. Our gratitude does not imply their endorsement.


### PR DESCRIPTION
PRing from a fork, so that you can visually see what I'm proposing to merge, over at this temporary URL:

http://konklone.io/licensing/

This PR does a few things related to signing:
- I've added more signed on organizations.
- I've broken out the signing section into two parts, "Authors" and "Supporters"
- I de-linked the org names for the Authors section, where it's the less important part, since the org is reflected below that in Supporters. 
- I converted it to a `<ul>` list and re-styled the section. Links for organizations are now bold, and underlined/recolored on hover.

**Question: would Authors like their names linked to anything?** I'm thinking of linking mine to my Twitter account, for instance.

And then some other things:
- I was getting some reports of the webfont I use (Average) looking totally terrible on government computers running Windows and IE 8 and 9. I've left the headers as Average, but set every other font to 11pt Times New Roman. I'm hoping this is temporary, and I'll work on [possible fixes](http://stackoverflow.com/questions/10953037/google-webfonts-render-choppy-in-chrome-on-windows) for the problem, or at least a better font.
- I added a `/v1.html` page with the first version, and linked the first History item to it.
- I added a line to the sidebar about how the document is written and supported by various people

/cc @jwyg @joshdata @thisisparker @mwweinberg
