### PR TITLE
Restore a 'however'

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,7 +47,7 @@ The White House's [Project Open Data](http://project-open-data.github.io/) requi
 
 If a statutory exemption to 17 USC § 105 is applicable, use:
 
-> This is a work of the United States Government that is exempt from 17 USC § 105. Additionally, [Agency Name] waives copyright and related rights in the work worldwide through the CC0 1.0 Universal Public Domain Dedication (which can be found at [http://creativecommons.org/publicdomain/zero/1.0/](http://creativecommons.org/publicdomain/zero/1.0/)).
+> This is a work of the United States Government that is exempt from 17 USC § 105. However, [Agency Name] waives copyright and related rights in the work worldwide through the CC0 1.0 Universal Public Domain Dedication (which can be found at [http://creativecommons.org/publicdomain/zero/1.0/](http://creativecommons.org/publicdomain/zero/1.0/)).
 
 #### For Government Works Produced by a Contractor
 


### PR DESCRIPTION
This 'however' was changed to 'additionally' in #5, suggested by @mwweinberg, to avoid implying a contradiction that wasn't there, but I think we all might have read it too fast. The sentence it begins is actually in contrast to the previous sentence, because we're talking about works that have a statutory exemption _from_ the exemption from copyright (and have been granted US copyrightability).

I'm proposing this as a merge into `v3`, as I don't want to disturb the doc, and it's not a really important change (doesn't change the substantive text at all) and can wait as long as is needed.
