### PR TITLE
Link to GitHub and to the doc's own CC0 license

### DIFF
--- a/index.md
+++ b/index.md
@@ -135,3 +135,6 @@ We also thank Timothy Vollmer, Puneet Kishor, and other reviewers for their disc
 December 12, 2013. Rewrote the introduction. Removed "However"s in the suggested language. Added sections on determining IP status, that data is not copyrightable as such, and that this applies to software as well as data. Corrected typos. Updated signers list.
 
 April 7/15, 2013. Added Creative Commons as a supporter; added Timothy Vollmer as an author.
+
+This document itself is <a href="https://github.com/unitedstates/licensing">hosted on GitHub</a>, and released under a <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 1.0 Universal public domain dedication</a>.
+{:.small}


### PR DESCRIPTION
This adds a small footer with a sentence that links to this GitHub repository, and mentions that the document itself is released under a CC0 license.

This seems non-substantive and fine to add in-place. I'll merge a bit later today, barring any :-1:'s.
