### PR TITLE
Update links, remove Census as an example

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,14 +1,18 @@
-Some background on this document and why it exists, in rough chronological order.
+Some background on this document, its history and impact, in rough chronological order.
 
-* [April 4, 2013](https://twitter.com/vdavez/status/319840540025843712?t=1&refsrc=email&iid=8dc3ab45-3c58-4ee6-aca5-944769eec59b&uid=352686442&nid=4+251). **[@JoshData](https://github.com/JoshData)** worked with the DC Council to get the DC Code [released under a CC0 public domain license](http://dccouncil.us/UnofficialDCCode), following a kerfuffle raised by **[@tmcw](https://github.com/tmcw)** over its [prior lack of public availability](http://macwright.org/2013/02/20/you-cannot-have-the-code.html) outside of a locked-down vendor.
+## History 
 
-* May 9, 2013. The White House published a [Memorandum on Open Data Policy (M-13-13)](https://www.whitehouse.gov/sites/default/files/omb/memoranda/2013/m-13-13.pdf) and a related [executive order](https://www.whitehouse.gov/the-press-office/2013/05/09/executive-order-making-open-and-machine-readable-new-default-government-). The policy recommended the use of "open licensing" for all open government data. [@JoshData](https://github.com/JoshData) wrote that this was [a step backward](http://razor.occams.info/blog/2013/05/09/new-open-data-memorandum-almost-defines-open-data-misses-mark-with-open-licenses/).
+* [April 4, 2013](https://twitter.com/vdavez/status/319840540025843712?t=1&refsrc=email&iid=8dc3ab45-3c58-4ee6-aca5-944769eec59b&uid=352686442&nid=4+251). **[@JoshData](https://github.com/JoshData)** worked with the DC Council to get the DC Code [released under a CC0 public domain license](https://dccouncil.us/UnofficialDCCode), following a kerfuffle raised by **[@tmcw](https://github.com/tmcw)** over its [prior lack of public availability](https://macwright.org/2013/02/20/you-cannot-have-the-code.html) outside of a locked-down vendor.
+
+* May 9, 2013. The White House published a [Memorandum on Open Data Policy (M-13-13)](https://www.whitehouse.gov/sites/default/files/omb/memoranda/2013/m-13-13.pdf) and a related [executive order](https://www.whitehouse.gov/the-press-office/2013/05/09/executive-order-making-open-and-machine-readable-new-default-government-). The policy recommended the use of "open licensing" for all open government data. [@JoshData](https://github.com/JoshData) wrote that this was [a step backward](https://razor.occams.info/blog/2013/05/09/new-open-data-memorandum-almost-defines-open-data-misses-mark-with-open-licenses/).
 
 * May 31, 2013. **[@JoshData](https://github.com/JoshData)**'s contract work for HHS also gave him the opportunity to try out some very simple, best practice [license language](https://github.com/HHS/ckanext-datajson#credit--copying) on a CKAN extension he worked on for HealthData.gov.
 
 * May-June 2013. The White House released [Project Open Data](https://project-open-data.cio.gov), its guidance for agencies in implementing the Obama administration's open data executive order. **[@JoshData](https://github.com/JoshData)** and **[@konklone](https://github.com/konklone)**, along with others, opened [some](https://github.com/project-open-data/project-open-data.github.io/issues/5) [discussions](https://github.com/project-open-data/project-open-data.github.io/pull/64) with Project Open Data, encouraging its [licensing section](https://project-open-data.cio.gov/license-examples/) to have stronger language and clearer norms around the nature of license-free US government information.
 
-* August 19, 2013. To clarify the issue, **[@JoshData](https://github.com/JoshData)**, **[@konklone](https://github.com/konklone)**, and **[@jwyg](https://github.com/jwyg)**, with help from **[@tvol](https://github.com/tvol)** and **[@punkish](https://github.com/punkish)**, produced [version 1](http://razor.occams.info/pubdocs/2013-08-19_license_free.pdf) of this guidance document, referencing the two previous in-government examples **[@JoshData](https://github.com/JoshData)** had worked on, and he [blogged about the motivation](http://razor.occams.info/blog/2013/08/19/guidance-federal-agencies-can-make-their-data-license-free/).
+* August 19, 2013. To clarify the issue, **[@JoshData](https://github.com/JoshData)**, **[@konklone](https://github.com/konklone)**, and **[@jwyg](https://github.com/jwyg)**, with help from **[@tvol](https://github.com/tvol)** and **[@punkish](https://github.com/punkish)**, produced [version 1](https://razor.occams.info/pubdocs/2013-08-19_license_free.pdf) of this guidance document, referencing the two previous in-government examples **[@JoshData](https://github.com/JoshData)** had worked on, and he [blogged about the motivation](https://razor.occams.info/blog/2013/08/19/guidance-federal-agencies-can-make-their-data-license-free/).
+
+## Impact
 
 * August 25, 2013. Partly in response to our nudging, Project Open Data (POD) began the process to [re-license itself](https://github.com/project-open-data/project-open-data.github.io/pull/135) --- the POD schema and associated code --- as international public domain under CC0, and completed re-licensing on October 17, 2013. (This also yielded an interesting discussion around Unlicense vs CC0.)
 
@@ -27,7 +31,4 @@ Some background on this document and why it exists, in rough chronological order
 * August 12, 2014. The United States Digital Service (USDS) launches, along with a "Playbook" including a checklist on [defaulting to open](https://playbook.cio.gov/#play13) that specifically calls for dedicating government data to the international public domain and cites CC0.
 
 * November 23, 2015. The District of Columbia [makes CC0 the default for all DC open source projects](https://github.com/DCgov/license).
-
-* January 15, 2016. The US Census Bureau issues an [open source policy](https://github.com/uscensusbureau/open-source-policy) that [makes CC0 the default](https://github.com/uscensusbureau/open-source-policy#open-source-licenses) for Census works.
-
 


### PR DESCRIPTION
This updates the `HISTORY.md` file (not the published document) to add intermediate headers for pre- and post-publication, update some links to use https://, and remove the link to the Census. (It doesn't seem to have ever had the real backing of the Census, and now 404's.)